### PR TITLE
Fixed module imports.

### DIFF
--- a/examples/core_2d_fillet.py
+++ b/examples/core_2d_fillet.py
@@ -15,9 +15,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Pnt,gp_Dir,gp_Pln
-from OCC.Core.ChFi2d import ChFi2d_AnaFilletAlgo
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge,BRepBuilderAPI_MakeWire
+from OCC.gp import gp_Pnt,gp_Dir,gp_Pln
+from OCC.ChFi2d import ChFi2d_AnaFilletAlgo
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge,BRepBuilderAPI_MakeWire
 
 from OCC.Extend.ShapeFactory import make_wire
 

--- a/examples/core_animation.py
+++ b/examples/core_animation.py
@@ -22,9 +22,9 @@ from __future__ import print_function
 import time
 from math import pi
 
-from OCC.Core.gp import gp_Ax1, gp_Pnt, gp_Dir, gp_Trsf
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.TopLoc import TopLoc_Location
+from OCC.gp import gp_Ax1, gp_Pnt, gp_Dir, gp_Trsf
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.TopLoc import TopLoc_Location
 from OCC.Display.SimpleGui import init_display
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_boolean_fuzzy_cut_emmenthaler.py
+++ b/examples/core_boolean_fuzzy_cut_emmenthaler.py
@@ -21,10 +21,10 @@ import random
 import time
 import sys
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder, BRepPrimAPI_MakeCone
-from OCC.Core.gp import gp_Pnt, gp_Vec, gp_Ax2, gp_Dir
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
-from OCC.Core.TopTools import TopTools_ListOfShape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder, BRepPrimAPI_MakeCone
+from OCC.gp import gp_Pnt, gp_Vec, gp_Ax2, gp_Dir
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut
+from OCC.TopTools import TopTools_ListOfShape
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_classic_occ_bottle.py
+++ b/examples/core_classic_occ_bottle.py
@@ -19,23 +19,23 @@
 
 import math
 
-from OCC.Core.gp import gp_Pnt, gp_OX, gp_Vec, gp_Trsf, gp_DZ, gp_Ax2, gp_Ax3, gp_Pnt2d, gp_Dir2d, gp_Ax2d
-from OCC.Core.GC import GC_MakeArcOfCircle, GC_MakeSegment
-from OCC.Core.GCE2d import GCE2d_MakeSegment
-from OCC.Core.Geom import Geom_Plane, Geom_CylindricalSurface, Handle_Geom_Plane, Handle_Geom_Surface
-from OCC.Core.Geom2d import Geom2d_Ellipse, Geom2d_TrimmedCurve, Handle_Geom2d_Ellipse, Handle_Geom2d_Curve
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeFace, \
+from OCC.gp import gp_Pnt, gp_OX, gp_Vec, gp_Trsf, gp_DZ, gp_Ax2, gp_Ax3, gp_Pnt2d, gp_Dir2d, gp_Ax2d
+from OCC.GC import GC_MakeArcOfCircle, GC_MakeSegment
+from OCC.GCE2d import GCE2d_MakeSegment
+from OCC.Geom import Geom_Plane, Geom_CylindricalSurface, Handle_Geom_Plane, Handle_Geom_Surface
+from OCC.Geom2d import Geom2d_Ellipse, Geom2d_TrimmedCurve, Handle_Geom2d_Ellipse, Handle_Geom2d_Curve
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeFace, \
     BRepBuilderAPI_Transform
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism, BRepPrimAPI_MakeCylinder
-from OCC.Core.BRepFilletAPI import BRepFilletAPI_MakeFillet
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeThickSolid, BRepOffsetAPI_ThruSections
-from OCC.Core.BRepLib import breplib
-from OCC.Core.BRep import BRep_Tool_Surface, BRep_Builder
-from OCC.Core.TopoDS import topods, TopoDS_Edge, TopoDS_Compound
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopAbs import TopAbs_EDGE, TopAbs_FACE
-from OCC.Core.TopTools import TopTools_ListOfShape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakePrism, BRepPrimAPI_MakeCylinder
+from OCC.BRepFilletAPI import BRepFilletAPI_MakeFillet
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Fuse
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakeThickSolid, BRepOffsetAPI_ThruSections
+from OCC.BRepLib import breplib
+from OCC.BRep import BRep_Tool_Surface, BRep_Builder
+from OCC.TopoDS import topods, TopoDS_Edge, TopoDS_Compound
+from OCC.TopExp import TopExp_Explorer
+from OCC.TopAbs import TopAbs_EDGE, TopAbs_FACE
+from OCC.TopTools import TopTools_ListOfShape
 
 def face_is_plane(face):
     """

--- a/examples/core_dimensions.py
+++ b/examples/core_dimensions.py
@@ -17,9 +17,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Dir, gp_Ax2, gp_Circ, gp_Pnt
-from OCC.Core.AIS import AIS_Shape, AIS_RadiusDimension
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
+from OCC.gp import gp_Dir, gp_Ax2, gp_Circ, gp_Pnt
+from OCC.AIS import AIS_Shape, AIS_RadiusDimension
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCC.Display.SimpleGui import init_display
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_display_background_gradient_color.py
+++ b/examples/core_display_background_gradient_color.py
@@ -16,8 +16,8 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.Quantity import Quantity_NOC_ALICEBLUE, Quantity_NOC_ANTIQUEWHITE
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.Quantity import Quantity_NOC_ALICEBLUE, Quantity_NOC_ANTIQUEWHITE
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_display_background_image.py
+++ b/examples/core_display_background_image.py
@@ -16,7 +16,7 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_display_callbacks.py
+++ b/examples/core_display_callbacks.py
@@ -15,9 +15,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
-from OCC.Core.Bnd import Bnd_Box
-from OCC.Core.BRepBndLib import brepbndlib_Add
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
+from OCC.Bnd import Bnd_Box
+from OCC.BRepBndLib import brepbndlib_Add
 from OCC.Display.SimpleGui import init_display
 
 

--- a/examples/core_display_camera_projection.py
+++ b/examples/core_display_camera_projection.py
@@ -17,10 +17,10 @@
 import sys
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Graphic3d import Graphic3d_RenderingParams
-from OCC.Core.BRepTools import breptools_Read
-from OCC.Core.TopoDS import TopoDS_Shape
-from OCC.Core.BRep import BRep_Builder
+from OCC.Graphic3d import Graphic3d_RenderingParams
+from OCC.BRepTools import breptools_Read
+from OCC.TopoDS import TopoDS_Shape
+from OCC.BRep import BRep_Builder
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_display_clip_planes.py
+++ b/examples/core_display_clip_planes.py
@@ -21,12 +21,12 @@ from __future__ import print_function
 
 import sys
 
-from OCC.Core.gp import gp_Vec
-from OCC.Core.Graphic3d import Graphic3d_ClipPlane
-from OCC.Core.Quantity import Quantity_Color, Quantity_TOC_RGB
-from OCC.Core.BRepTools import breptools_Read
-from OCC.Core.TopoDS import TopoDS_Shape
-from OCC.Core.BRep import BRep_Builder
+from OCC.gp import gp_Vec
+from OCC.Graphic3d import Graphic3d_ClipPlane
+from OCC.Quantity import Quantity_Color, Quantity_TOC_RGB
+from OCC.BRepTools import breptools_Read
+from OCC.TopoDS import TopoDS_Shape
+from OCC.BRep import BRep_Builder
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_display_customize_linewidth.py
+++ b/examples/core_display_customize_linewidth.py
@@ -18,8 +18,8 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from OCC.Core.AIS import AIS_Shape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.AIS import AIS_Shape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_display_customize_prs3d.py
+++ b/examples/core_display_customize_prs3d.py
@@ -22,7 +22,7 @@
 # Be carful that improving quality results in higher memory consumption
 #
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeCylinder
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeCylinder
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()
 display.SetModeHLR()

--- a/examples/core_display_export_to_EF.py
+++ b/examples/core_display_export_to_EF.py
@@ -16,8 +16,8 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeTorus
-from OCC.Core.Graphic3d import (Graphic3d_EF_PDF,
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeTorus
+from OCC.Graphic3d import (Graphic3d_EF_PDF,
                            Graphic3d_EF_SVG,
                            Graphic3d_EF_TEX,
                            Graphic3d_EF_PostScript,

--- a/examples/core_display_export_to_image.py
+++ b/examples/core_display_export_to_image.py
@@ -18,7 +18,7 @@
 import sys
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_display_line_properties.py
+++ b/examples/core_display_line_properties.py
@@ -21,10 +21,10 @@ from __future__ import print_function
 
 import sys
 
-from OCC.Core.gp import gp_Pnt, gp_Dir
-from OCC.Core.Geom import Geom_Line
-from OCC.Core.AIS import AIS_Line
-from OCC.Core.Prs3d import Prs3d_LineAspect, Prs3d_Drawer
+from OCC.gp import gp_Pnt, gp_Dir
+from OCC.Geom import Geom_Line
+from OCC.AIS import AIS_Line
+from OCC.Prs3d import Prs3d_LineAspect, Prs3d_Drawer
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_display_overlayered_image.py
+++ b/examples/core_display_overlayered_image.py
@@ -17,8 +17,8 @@
 
 from math import pi
 
-from OCC.Core.TCollection import TCollection_AsciiString
-from OCC.Core.Addons import TextureItem
+from OCC.TCollection import TCollection_AsciiString
+from OCC.Addons import TextureItem
 from OCC.Display.SimpleGui import init_display
 
 # load the bottle

--- a/examples/core_display_overlayered_lines.py
+++ b/examples/core_display_overlayered_lines.py
@@ -20,8 +20,8 @@ import random
 from math import pi
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Addons import LineItem
-from OCC.Core.Quantity import Quantity_Color
+from OCC.Addons import LineItem
+from OCC.Quantity import Quantity_Color
 
 # load the bottle
 from core_classic_occ_bottle import bottle

--- a/examples/core_display_overlayered_text.py
+++ b/examples/core_display_overlayered_text.py
@@ -18,13 +18,13 @@
 import random
 from math import pi
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.Aspect import Aspect_TODT_NORMAL, Aspect_TODT_DEKALE 
-from OCC.Core.Quantity import Quantity_Color, Quantity_NOC_BLACK, Quantity_NOC_ORANGE
-from OCC.Core.TCollection import TCollection_AsciiString
-from OCC.Core.gp import gp_Ax1, gp_Pnt, gp_Dir, gp_Trsf
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.Addons import TextItem
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.Aspect import Aspect_TODT_NORMAL, Aspect_TODT_DEKALE 
+from OCC.Quantity import Quantity_Color, Quantity_NOC_BLACK, Quantity_NOC_ORANGE
+from OCC.TCollection import TCollection_AsciiString
+from OCC.gp import gp_Ax1, gp_Pnt, gp_Dir, gp_Trsf
+from OCC.TopLoc import TopLoc_Location
+from OCC.Addons import TextItem
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_display_point_cloud.py
+++ b/examples/core_display_point_cloud.py
@@ -20,8 +20,8 @@
 import os
 import random
 
-from OCC.Core.Graphic3d import Graphic3d_ArrayOfPoints
-from OCC.Core.AIS import AIS_PointCloud
+from OCC.Graphic3d import Graphic3d_ArrayOfPoints
+from OCC.AIS import AIS_PointCloud
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_display_quality.py
+++ b/examples/core_display_quality.py
@@ -22,7 +22,7 @@
 # Be carful that improving quality results in higher memory consumption
 #
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeCylinder
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeCylinder
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_display_raytracing.py
+++ b/examples/core_display_raytracing.py
@@ -18,12 +18,12 @@
 import sys
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCone
-from OCC.Core.Graphic3d import Graphic3d_NOM_PLASTIC, Graphic3d_NOM_ALUMINIUM
-from OCC.Core.V3d import V3d_SpotLight, V3d_COMPLETE, V3d_XnegYnegZpos
-from OCC.Core.Quantity import Quantity_NOC_WHITE, Quantity_NOC_CORAL2, Quantity_NOC_BROWN
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
-from OCC.Core.gp import gp_Vec
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCone
+from OCC.Graphic3d import Graphic3d_NOM_PLASTIC, Graphic3d_NOM_ALUMINIUM
+from OCC.V3d import V3d_SpotLight, V3d_COMPLETE, V3d_XnegYnegZpos
+from OCC.Quantity import Quantity_NOC_WHITE, Quantity_NOC_CORAL2, Quantity_NOC_BROWN
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut
+from OCC.gp import gp_Vec
 
 from OCC.Extend.ShapeFactory import translate_shp
 

--- a/examples/core_display_set_edge_color.py
+++ b/examples/core_display_set_edge_color.py
@@ -15,9 +15,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.AIS import AIS_Shape
-from OCC.Core.Quantity import Quantity_NOC_BLACK
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.AIS import AIS_Shape
+from OCC.Quantity import Quantity_NOC_BLACK
 from OCC.Display.SimpleGui import init_display
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_display_signal_slots.py
+++ b/examples/core_display_signal_slots.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 import sys
 
-from OCC.Core.BRepGProp import brepgprop_LinearProperties
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
+from OCC.BRepGProp import brepgprop_LinearProperties
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
 from OCC.Display.SimpleGui import init_display
 from OCC.Display.backend import get_qt_modules
-from OCC.Core.GProp import GProp_GProps
-from OCC.Core.TopAbs import TopAbs_SOLID, TopAbs_EDGE, TopAbs_FACE
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.gp import gp_Trsf, gp_Vec
+from OCC.GProp import GProp_GProps
+from OCC.TopAbs import TopAbs_SOLID, TopAbs_EDGE, TopAbs_FACE
+from OCC.TopLoc import TopLoc_Location
+from OCC.gp import gp_Trsf, gp_Vec
 
 display, start_display, add_menu, add_function_to_menu = init_display("qt-pyqt5")
-QtCore, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
+Q, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
 
 from OCC.Display.qtDisplay import qtViewer3d
 

--- a/examples/core_display_textured_shape.py
+++ b/examples/core_display_textured_shape.py
@@ -19,8 +19,8 @@
 
 import os
 
-from OCC.Core.Graphic3d import Graphic3d_NOM_SILVER, Graphic3d_MaterialAspect
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeCylinder
+from OCC.Graphic3d import Graphic3d_NOM_SILVER, Graphic3d_MaterialAspect
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeCylinder
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_display_z_order_transparency.py
+++ b/examples/core_display_z_order_transparency.py
@@ -15,9 +15,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.gp import gp_Vec, gp_Pnt
+from OCC.gp import gp_Vec, gp_Pnt
 
 from OCC.Extend.ShapeFactory import translate_shp
 

--- a/examples/core_export_step_ap203.py
+++ b/examples/core_export_step_ap203.py
@@ -19,11 +19,11 @@
 
 from __future__ import print_function
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
-from OCC.Core.STEPControl import STEPControl_Writer, STEPControl_AsIs
-from OCC.Core.Interface import Interface_Static_SetCVal
-from OCC.Core.IFSelect import IFSelect_RetDone
+from OCC.STEPControl import STEPControl_Writer, STEPControl_AsIs
+from OCC.Interface import Interface_Static_SetCVal
+from OCC.IFSelect import IFSelect_RetDone
 
 # creates a basic shape
 box_s = BRepPrimAPI_MakeBox(10, 20, 30).Shape()

--- a/examples/core_export_stl.py
+++ b/examples/core_export_stl.py
@@ -17,7 +17,7 @@
 
 import os
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeTorus
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeTorus
 from OCC.Extend.DataExchange import write_stl_file
 
 # first, create the shape

--- a/examples/core_font_3d_console.py
+++ b/examples/core_font_3d_console.py
@@ -19,8 +19,8 @@ import sys
 from code import InteractiveConsole
 from StringIO import StringIO
 
-from OCC.Core.gp import gp_Vec
-from OCC.Core.Addons import text_to_brep, Font_FA_Bold
+from OCC.gp import gp_Vec
+from OCC.Addons import text_to_brep, Font_FA_Bold
 
 from OCC.Display.SimpleGui import init_display
 from OCC.Extend.ShapeFactory import translate_shp, make_extrusion
@@ -29,7 +29,7 @@ display, start_display, add_menu, add_function_to_menu = init_display()
 
 from OCC.Display.qtDisplay import qtViewer3d
 from OCC.Display.backend import get_qt_modules
-QtCore, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
+Q, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
 
 
 def display_str_at_pos(stri, col, line):
@@ -68,16 +68,16 @@ python_cmd = ""
 def newKeyReleaseEvent(event):
     global shift_pressed
     code = event.key()
-    if code == QtCore.Qt.Key_Shift:
+    if code == Q.Qt.Key_Shift:
         shift_pressed = False
         print("Shift released")
 
 def newkeyPressEvent(event):
     global python_cmd, col, lin, shift_pressed
     code = event.key()
-    if code == QtCore.Qt.Key_Shift:
+    if code == Q.Qt.Key_Shift:
         shift_pressed = True
-    elif code == QtCore.Qt.Key_Return or code == QtCore.Qt.Key_Enter:  # enter key
+    elif code == Q.Qt.Key_Return or code == Q.Qt.Key_Enter:  # enter key
         # pass the python command to the interpreter
         output = c.runcode(python_cmd)
         lines = output.splitlines()
@@ -90,7 +90,7 @@ def newkeyPressEvent(event):
         ### display prompt below
         display_str_at_pos(">>>", 0, lin)
         col = 3
-    elif code == QtCore.Qt.Key_Escape:
+    elif code == Q.Qt.Key_Escape:
         sys.exit(0)
     else:
         if code > 255:

--- a/examples/core_font_helloworld.py
+++ b/examples/core_font_helloworld.py
@@ -16,7 +16,7 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Addons import text_to_brep, Font_FA_Bold
+from OCC.Addons import text_to_brep, Font_FA_Bold
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_font_register.py
+++ b/examples/core_font_register.py
@@ -19,7 +19,7 @@
 import os
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Addons import text_to_brep, register_font, Font_FA_Bold, Font_FA_Regular
+from OCC.Addons import text_to_brep, register_font, Font_FA_Bold, Font_FA_Regular
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_font_unicode.py
+++ b/examples/core_font_unicode.py
@@ -17,11 +17,11 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 import random
-from OCC.Core.gp import gp_Vec
-from OCC.Core.Quantity import Quantity_Color, Quantity_TOC_RGB
+from OCC.gp import gp_Vec
+from OCC.Quantity import Quantity_Color, Quantity_TOC_RGB
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Addons import text_to_brep, Font_FA_Regular
+from OCC.Addons import text_to_brep, Font_FA_Regular
 
 from OCC.Extend.ShapeFactory import translate_shp, make_extrusion
 

--- a/examples/core_geometry_airfoil.py
+++ b/examples/core_geometry_airfoil.py
@@ -26,12 +26,12 @@ try:
 except ImportError:
     import urllib2  # Python2
 
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism
-from OCC.Core.Geom2dAPI import Geom2dAPI_PointsToBSpline
-from OCC.Core.GeomAPI import geomapi
-from OCC.Core.gp import gp_Pnt, gp_Vec, gp_Pnt2d, gp_Pln, gp_Dir
-from OCC.Core.TColgp import TColgp_Array1OfPnt2d
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+from OCC.BRepPrimAPI import BRepPrimAPI_MakePrism
+from OCC.Geom2dAPI import Geom2dAPI_PointsToBSpline
+from OCC.GeomAPI import geomapi
+from OCC.gp import gp_Pnt, gp_Vec, gp_Pnt2d, gp_Pln, gp_Dir
+from OCC.TColgp import TColgp_Array1OfPnt2d
 from OCC.Display.SimpleGui import init_display
     
 from OCC.Extend.ShapeFactory import make_wire, make_edge

--- a/examples/core_geometry_axis.py
+++ b/examples/core_geometry_axis.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 import sys
 
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Ax3
+from OCC.gp import gp_Pnt, gp_Dir, gp_Ax3
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_bisector.py
+++ b/examples/core_geometry_bisector.py
@@ -18,11 +18,11 @@
 import os
 import sys
 
-from OCC.Core.Bisector import Bisector_BisecCC
+from OCC.Bisector import Bisector_BisecCC
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.GCE2d import GCE2d_MakeLine, GCE2d_MakeCircle
-from OCC.Core.GccAna import GccAna_Lin2dBisec, GccAna_CircLin2dBisec, GccAna_Pnt2dBisec
-from OCC.Core.gp import gp_Lin2d, gp_Pnt2d, gp_Dir2d, gp_Circ2d, gp_Ax22d, gp_Pnt
+from OCC.GCE2d import GCE2d_MakeLine, GCE2d_MakeCircle
+from OCC.GccAna import GccAna_Lin2dBisec, GccAna_CircLin2dBisec, GccAna_Pnt2dBisec
+from OCC.gp import gp_Lin2d, gp_Pnt2d, gp_Dir2d, gp_Circ2d, gp_Ax22d, gp_Pnt
 
 from OCC.Extend.ShapeFactory import make_vertex, make_edge2d
 

--- a/examples/core_geometry_bounding_box.py
+++ b/examples/core_geometry_bounding_box.py
@@ -17,10 +17,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.Bnd import Bnd_Box
-from OCC.Core.BRepBndLib import brepbndlib_Add
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
-from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
+from OCC.Bnd import Bnd_Box
+from OCC.BRepBndLib import brepbndlib_Add
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
+from OCC.BRepMesh import BRepMesh_IncrementalMesh
 
 
 def get_boundingbox(shape, tol=1e-6, use_mesh=True):

--- a/examples/core_geometry_bspline.py
+++ b/examples/core_geometry_bspline.py
@@ -19,9 +19,9 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt2d
-from OCC.Core.Geom2dAPI import Geom2dAPI_Interpolate, Geom2dAPI_PointsToBSpline
-from OCC.Core.TColgp import TColgp_HArray1OfPnt2d, TColgp_Array1OfPnt2d
+from OCC.gp import gp_Pnt2d
+from OCC.Geom2dAPI import Geom2dAPI_Interpolate, Geom2dAPI_PointsToBSpline
+from OCC.TColgp import TColgp_HArray1OfPnt2d, TColgp_Array1OfPnt2d
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_curves2d_from_curve.py
+++ b/examples/core_geometry_curves2d_from_curve.py
@@ -19,11 +19,11 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_OX2d
-from OCC.Core.GCE2d import GCE2d_MakeEllipse
-from OCC.Core.Geom2d import Geom2d_TrimmedCurve
-from OCC.Core.Geom2dConvert import geom2dconvert_CurveToBSplineCurve
-from OCC.Core.Convert import Convert_TgtThetaOver2
+from OCC.gp import gp_OX2d
+from OCC.GCE2d import GCE2d_MakeEllipse
+from OCC.Geom2d import Geom2d_TrimmedCurve
+from OCC.Geom2dConvert import geom2dconvert_CurveToBSplineCurve
+from OCC.Convert import Convert_TgtThetaOver2
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_curves2d_from_offset.py
+++ b/examples/core_geometry_curves2d_from_offset.py
@@ -19,10 +19,10 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt2d
-from OCC.Core.TColgp import TColgp_Array1OfPnt2d
-from OCC.Core.Geom2dAPI import Geom2dAPI_PointsToBSpline
-from OCC.Core.Geom2d import Geom2d_OffsetCurve
+from OCC.gp import gp_Pnt2d
+from OCC.TColgp import TColgp_Array1OfPnt2d
+from OCC.Geom2dAPI import Geom2dAPI_PointsToBSpline
+from OCC.Geom2d import Geom2d_OffsetCurve
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_ellipsoid.py
+++ b/examples/core_geometry_ellipsoid.py
@@ -15,10 +15,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Pnt, gp_XYZ, gp_Mat, gp_GTrsf
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeBox
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_GTransform
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Common
+from OCC.gp import gp_Pnt, gp_XYZ, gp_Mat, gp_GTrsf
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeBox
+from OCC.BRepBuilderAPI import BRepBuilderAPI_GTransform
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Common
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_geometry_face_recognition_from_stepfile.py
+++ b/examples/core_geometry_face_recognition_from_stepfile.py
@@ -36,11 +36,11 @@ import os.path
 import sys
 
 
-from OCC.Core.STEPControl import STEPControl_Reader
-from OCC.Core.IFSelect import IFSelect_RetDone, IFSelect_ItemsByEntity
-from OCC.Core.GeomAbs import GeomAbs_Plane, GeomAbs_Cylinder
-from OCC.Core.TopoDS import topods_Face
-from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
+from OCC.STEPControl import STEPControl_Reader
+from OCC.IFSelect import IFSelect_RetDone, IFSelect_ItemsByEntity
+from OCC.GeomAbs import GeomAbs_Plane, GeomAbs_Cylinder
+from OCC.TopoDS import topods_Face
+from OCC.BRepAdaptor import BRepAdaptor_Surface
 from OCC.Display.SimpleGui import init_display
 
 from OCC.Extend.TopologyUtils import TopologyExplorer

--- a/examples/core_geometry_faircurve.py
+++ b/examples/core_geometry_faircurve.py
@@ -23,10 +23,10 @@ import math
 import time
 import sys
 
-from OCC.Core.gp import gp_Pnt2d, gp_Pln
-from OCC.Core.Geom import Geom_Plane
-from OCC.Core.FairCurve import FairCurve_MinimalVariation
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
+from OCC.gp import gp_Pnt2d, gp_Pln
+from OCC.Geom import Geom_Plane
+from OCC.FairCurve import FairCurve_MinimalVariation
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_geometry_geomplate.py
+++ b/examples/core_geometry_geomplate.py
@@ -20,19 +20,19 @@ import os
 import sys
 import time
 
-from OCC.Core.BRep import BRep_Tool
-from OCC.Core.BRepAdaptor import BRepAdaptor_HCurve
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakePolygon
-from OCC.Core.BRepFill import BRepFill_CurveConstraint
+from OCC.BRep import BRep_Tool
+from OCC.BRepAdaptor import BRepAdaptor_HCurve
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakePolygon
+from OCC.BRepFill import BRepFill_CurveConstraint
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.GeomAbs import GeomAbs_C0
-from OCC.Core.GeomLProp import GeomLProp_SLProps
-from OCC.Core.GeomLProp import GeomLProp_SurfaceTool
-from OCC.Core.GeomPlate import (GeomPlate_BuildPlateSurface, GeomPlate_PointConstraint,
+from OCC.GeomAbs import GeomAbs_C0
+from OCC.GeomLProp import GeomLProp_SLProps
+from OCC.GeomLProp import GeomLProp_SurfaceTool
+from OCC.GeomPlate import (GeomPlate_BuildPlateSurface, GeomPlate_PointConstraint,
 	                       GeomPlate_MakeApprox)
-from OCC.Core.ShapeAnalysis import ShapeAnalysis_Surface
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepFill import BRepFill_Filling
+from OCC.ShapeAnalysis import ShapeAnalysis_Surface
+from OCC.gp import gp_Pnt
+from OCC.BRepFill import BRepFill_Filling
 
 from OCC.Extend.TopologyUtils import TopologyExplorer, WireExplorer
 from OCC.Extend.ShapeFactory import make_face, make_vertex

--- a/examples/core_geometry_medial_axis_offset.py
+++ b/examples/core_geometry_medial_axis_offset.py
@@ -19,10 +19,10 @@
 
 # this example was ported from: http://heekscnc.blogspot.nl/2009/09/occ-offset.html, by Dan Heeks
 
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeOffset
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakeOffset
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.GeomAbs import GeomAbs_Arc
-from OCC.Core.gp import gp_Pnt
+from OCC.GeomAbs import GeomAbs_Arc
+from OCC.gp import gp_Pnt
 from OCC.Extend.ShapeFactory import make_edge, make_vertex, make_wire, make_face
 from OCC.Extend.TopologyUtils import TopologyExplorer
 
@@ -30,7 +30,7 @@ display, start_display, add_menu, add_function_to_menu = init_display()
 
 
 def boolean_cut(shapeToCutFrom, cuttingShape):
-    from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
+    from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut
     cut = BRepAlgoAPI_Cut(shapeToCutFrom, cuttingShape)
 
     if not cut.BuilderCanWork():

--- a/examples/core_geometry_minimal_distance.py
+++ b/examples/core_geometry_minimal_distance.py
@@ -19,10 +19,10 @@
 
 from __future__ import print_function
 
-from OCC.Core.BRepExtrema import BRepExtrema_DistShapeShape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepExtrema import BRepExtrema_DistShapeShape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.gp import gp_Pnt, gp_Ax2, gp_Circ
+from OCC.gp import gp_Pnt, gp_Ax2, gp_Circ
 
 from OCC.Extend.ShapeFactory import make_edge, make_vertex
 

--- a/examples/core_geometry_parabola.py
+++ b/examples/core_geometry_parabola.py
@@ -19,9 +19,9 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt2d, gp_Dir2d, gp_Ax22d, gp_Parab2d
-from OCC.Core.GCE2d import GCE2d_MakeParabola
-from OCC.Core.Geom2d import Geom2d_TrimmedCurve
+from OCC.gp import gp_Pnt2d, gp_Dir2d, gp_Ax22d, gp_Parab2d
+from OCC.GCE2d import GCE2d_MakeParabola
+from OCC.Geom2d import Geom2d_TrimmedCurve
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_point_from_curve.py
+++ b/examples/core_geometry_point_from_curve.py
@@ -17,10 +17,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Pnt, gp_Pnt2d, gp_OX2d
-from OCC.Core.Geom2d import Geom2d_Circle
-from OCC.Core.Geom2dAdaptor import Geom2dAdaptor_Curve
-from OCC.Core.GCPnts import GCPnts_UniformAbscissa
+from OCC.gp import gp_Pnt, gp_Pnt2d, gp_OX2d
+from OCC.Geom2d import Geom2d_Circle
+from OCC.Geom2dAdaptor import Geom2dAdaptor_Curve
+from OCC.GCPnts import GCPnts_UniformAbscissa
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_point_from_intersection.py
+++ b/examples/core_geometry_point_from_intersection.py
@@ -19,11 +19,11 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pln, gp_XOY, gp_Ax3, gp_YOZ, gp_Elips
-from OCC.Core.IntAna import IntAna_IntConicQuad
-from OCC.Core.Precision import precision_Angular, precision_Confusion
-from OCC.Core.GC import GC_MakePlane, GC_MakeEllipse
-from OCC.Core.Geom import Geom_RectangularTrimmedSurface
+from OCC.gp import gp_Pln, gp_XOY, gp_Ax3, gp_YOZ, gp_Elips
+from OCC.IntAna import IntAna_IntConicQuad
+from OCC.Precision import precision_Angular, precision_Confusion
+from OCC.GC import GC_MakePlane, GC_MakeEllipse
+from OCC.Geom import Geom_RectangularTrimmedSurface
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_project_point_on_curve.py
+++ b/examples/core_geometry_project_point_on_curve.py
@@ -19,9 +19,9 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt, gp_XOY
-from OCC.Core.GeomAPI import GeomAPI_ProjectPointOnCurve
-from OCC.Core.Geom import Geom_Circle
+from OCC.gp import gp_Pnt, gp_XOY
+from OCC.GeomAPI import GeomAPI_ProjectPointOnCurve
+from OCC.Geom import Geom_Circle
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_quaternion.py
+++ b/examples/core_geometry_quaternion.py
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.gp import gp_QuaternionSLerp, gp_Quaternion, gp_Vec, gp_Pnt
+from OCC.gp import gp_QuaternionSLerp, gp_Quaternion, gp_Vec, gp_Pnt
 from OCC.Extend.ShapeFactory import make_edge
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_geometry_splinecage.py
+++ b/examples/core_geometry_splinecage.py
@@ -23,11 +23,11 @@
 import os
 import random
 
-from OCC.Core.BRepAdaptor import BRepAdaptor_Curve
-from OCC.Core.GCPnts import GCPnts_AbscissaPoint, GCPnts_UniformAbscissa
-from OCC.Core.GeomAbs import GeomAbs_G1
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeFilling
-from OCC.Core.TopAbs import TopAbs_FACE, TopAbs_EDGE
+from OCC.BRepAdaptor import BRepAdaptor_Curve
+from OCC.GCPnts import GCPnts_AbscissaPoint, GCPnts_UniformAbscissa
+from OCC.GeomAbs import GeomAbs_G1
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakeFilling
+from OCC.TopAbs import TopAbs_FACE, TopAbs_EDGE
 
 from OCC.Display.SimpleGui import init_display
 from OCC.Display.OCCViewer import rgb_color

--- a/examples/core_geometry_surface_from_curves.py
+++ b/examples/core_geometry_surface_from_curves.py
@@ -19,13 +19,13 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt, gp_Vec
-from OCC.Core.GeomFill import (GeomFill_BSplineCurves,
+from OCC.gp import gp_Pnt, gp_Vec
+from OCC.GeomFill import (GeomFill_BSplineCurves,
                           GeomFill_StretchStyle,
                           GeomFill_CoonsStyle,
                           GeomFill_CurvedStyle)
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSpline
-from OCC.Core.Geom import Handle_Geom_BSplineCurve_DownCast
+from OCC.GeomAPI import GeomAPI_PointsToBSpline
+from OCC.Geom import Handle_Geom_BSplineCurve_DownCast
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_gfa.py
+++ b/examples/core_gfa.py
@@ -16,8 +16,8 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.BOPAlgo import BOPAlgo_Builder
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BOPAlgo import BOPAlgo_Builder
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box1 = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_helloworld.py
+++ b/examples/core_helloworld.py
@@ -33,7 +33,7 @@ pythonocc world and run all the other examples.
 """
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_inherit_topods_shape.py
+++ b/examples/core_inherit_topods_shape.py
@@ -17,10 +17,10 @@
 
 from __future__ import print_function
 
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
-from OCC.Core.TopoDS import TopoDS_Edge
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRep import BRep_Tool
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
+from OCC.TopoDS import TopoDS_Edge
+from OCC.gp import gp_Pnt
+from OCC.BRep import BRep_Tool
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_load_brep.py
+++ b/examples/core_load_brep.py
@@ -16,9 +16,9 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepTools import breptools_Read
-from OCC.Core.TopoDS import TopoDS_Shape
-from OCC.Core.BRep import BRep_Builder
+from OCC.BRepTools import breptools_Read
+from OCC.TopoDS import TopoDS_Shape
+from OCC.BRep import BRep_Builder
 
 cylinder_head = TopoDS_Shape()
 builder = BRep_Builder()

--- a/examples/core_load_step_ap203.py
+++ b/examples/core_load_step_ap203.py
@@ -22,7 +22,7 @@ import os
 import os.path
 import sys
 
-from OCC.Core.Quantity import Quantity_Color, Quantity_TOC_RGB
+from OCC.Quantity import Quantity_Color, Quantity_TOC_RGB
 from OCC.Display.SimpleGui import init_display
 
 from OCC.Extend.TopologyUtils import TopologyExplorer

--- a/examples/core_load_step_ap203_ocaf.py
+++ b/examples/core_load_step_ap203_ocaf.py
@@ -18,17 +18,17 @@
 from __future__ import print_function
 
 
-from OCC.Core.TCollection import TCollection_ExtendedString
+from OCC.TCollection import TCollection_ExtendedString
 
-from OCC.Core.TDocStd import Handle_TDocStd_Document
-from OCC.Core.XCAFApp import XCAFApp_Application
-from OCC.Core.XCAFDoc import (XCAFDoc_DocumentTool_ShapeTool,
+from OCC.TDocStd import Handle_TDocStd_Document
+from OCC.XCAFApp import XCAFApp_Application
+from OCC.XCAFDoc import (XCAFDoc_DocumentTool_ShapeTool,
                          XCAFDoc_DocumentTool_ColorTool,
                          XCAFDoc_DocumentTool_LayerTool,
                          XCAFDoc_DocumentTool_MaterialTool)
-from OCC.Core.STEPCAFControl import STEPCAFControl_Reader
-from OCC.Core.IFSelect import IFSelect_RetDone
-from OCC.Core.TDF import TDF_LabelSequence
+from OCC.STEPCAFControl import STEPCAFControl_Reader
+from OCC.IFSelect import IFSelect_RetDone
+from OCC.TDF import TDF_LabelSequence
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_load_step_with_colors.py
+++ b/examples/core_load_step_with_colors.py
@@ -19,20 +19,20 @@ from __future__ import print_function
 
 import sys
 
-from OCC.Core.TDocStd import Handle_TDocStd_Document
-from OCC.Core.XCAFApp import XCAFApp_Application
-from OCC.Core.XCAFDoc import (XCAFDoc_DocumentTool_ShapeTool,
+from OCC.TDocStd import Handle_TDocStd_Document
+from OCC.XCAFApp import XCAFApp_Application
+from OCC.XCAFDoc import (XCAFDoc_DocumentTool_ShapeTool,
                          XCAFDoc_DocumentTool_ColorTool,
                          XCAFDoc_DocumentTool_LayerTool,
                          XCAFDoc_DocumentTool_MaterialTool)
-from OCC.Core.STEPCAFControl import STEPCAFControl_Reader
-from OCC.Core.IFSelect import IFSelect_RetDone
-from OCC.Core.TDF import TDF_LabelSequence, TDF_Label, TDF_Tool
-from OCC.Core.TDataStd import Handle_TDataStd_Name, TDataStd_Name_GetID
-from OCC.Core.TCollection import TCollection_ExtendedString, TCollection_AsciiString
-from OCC.Core.Quantity import Quantity_Color
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_Transform
+from OCC.STEPCAFControl import STEPCAFControl_Reader
+from OCC.IFSelect import IFSelect_RetDone
+from OCC.TDF import TDF_LabelSequence, TDF_Label, TDF_Tool
+from OCC.TDataStd import Handle_TDataStd_Name, TDataStd_Name_GetID
+from OCC.TCollection import TCollection_ExtendedString, TCollection_AsciiString
+from OCC.Quantity import Quantity_Color
+from OCC.TopLoc import TopLoc_Location
+from OCC.BRepBuilderAPI import BRepBuilderAPI_Transform
 from OCC.Display.SimpleGui import init_display
 
 filename = '../assets/models/as1-oc-214.stp'

--- a/examples/core_matplotlib_box.py
+++ b/examples/core_matplotlib_box.py
@@ -22,8 +22,8 @@
 
 import sys
 
-from OCC.Core.Visualization import Tesselator
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.Visualization import Tesselator
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 try:
     from mpl_toolkits.mplot3d import Axes3D
     from matplotlib import pyplot as plt

--- a/examples/core_mesh_fast_stl_load.py
+++ b/examples/core_mesh_fast_stl_load.py
@@ -20,8 +20,8 @@ import time
 import os
 import os.path
 
-from OCC.Core.SMESH import SMESH_Gen, SMESH_MeshVSLink
-from OCC.Core.MeshVS import MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder, MeshVS_DMF_WireFrame
+from OCC.SMESH import SMESH_Gen, SMESH_MeshVSLink
+from OCC.MeshVS import MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder, MeshVS_DMF_WireFrame
 from OCC.Display.SimpleGui import init_display
 
 # Create the Mesh

--- a/examples/core_mesh_gmsh.py
+++ b/examples/core_mesh_gmsh.py
@@ -22,8 +22,8 @@ from __future__ import print_function
 import os
 import sys
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
-from OCC.Core.BRepTools import breptools_Write
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
+from OCC.BRepTools import breptools_Write
 
 from OCC.Display.SimpleGui import init_display
 from OCC.Extend.DataExchange import read_stl_file

--- a/examples/core_mesh_surfacic.py
+++ b/examples/core_mesh_surfacic.py
@@ -17,23 +17,23 @@
 
 import sys
 
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.TopAbs import TopAbs_FACE
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopoDS import TopoDS_Compound, topods_Face
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeFace
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSpline
-from OCC.Core.GeomFill import GeomFill_ConstrainedFilling, GeomFill_SimpleBound
-from OCC.Core.GeomAdaptor import GeomAdaptor_HCurve
-from OCC.Core.TColgp import TColgp_Array1OfPnt
-from OCC.Core.BRep import BRep_Builder, BRep_Tool
-from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.MeshVS import MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder, MeshVS_DMF_NodalColorDataPrs
+from OCC.gp import gp_Pnt
+from OCC.TopAbs import TopAbs_FACE
+from OCC.TopExp import TopExp_Explorer
+from OCC.TopoDS import TopoDS_Compound, topods_Face
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeFace
+from OCC.GeomAPI import GeomAPI_PointsToBSpline
+from OCC.GeomFill import GeomFill_ConstrainedFilling, GeomFill_SimpleBound
+from OCC.GeomAdaptor import GeomAdaptor_HCurve
+from OCC.TColgp import TColgp_Array1OfPnt
+from OCC.BRep import BRep_Builder, BRep_Tool
+from OCC.BRepMesh import BRepMesh_IncrementalMesh
+from OCC.TopLoc import TopLoc_Location
+from OCC.MeshVS import MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder, MeshVS_DMF_NodalColorDataPrs
 
 # SMESH wrappers
-from OCC.Core.SMESH import SMESH_Gen, SMESH_MeshVSLink
-from OCC.Core.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_TrianglePreference,
+from OCC.SMESH import SMESH_Gen, SMESH_MeshVSLink
+from OCC.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_TrianglePreference,
                             StdMeshers_Regular_1D, StdMeshers_Quadrangle_2D,
                             StdMeshers_MEFISTO_2D)
 

--- a/examples/core_mesh_traverse.py
+++ b/examples/core_mesh_traverse.py
@@ -15,9 +15,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.SMESH import SMESH_Gen
-from OCC.Core.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_Regular_1D,
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.SMESH import SMESH_Gen
+from OCC.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_Regular_1D,
                             StdMeshers_TrianglePreference, StdMeshers_MEFISTO_2D,
                             StdMeshers_QuadranglePreference, StdMeshers_Quadrangle_2D)
 

--- a/examples/core_mesh_volumic.py
+++ b/examples/core_mesh_volumic.py
@@ -16,16 +16,16 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut
-from OCC.Core.SMESH import SMESH_Gen, SMESH_MeshVSLink
-from OCC.Core.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_QuadranglePreference,
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
+from OCC.gp import gp_Pnt
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut
+from OCC.SMESH import SMESH_Gen, SMESH_MeshVSLink
+from OCC.StdMeshers import (StdMeshers_Arithmetic1D, StdMeshers_QuadranglePreference,
 	                        StdMeshers_Regular_1D, StdMeshers_Prism_3D, StdMeshers_CompositeHexa_3D,
 	                        StdMeshers_Quadrangle_2D)
-from OCC.Core.MeshVS import (MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder,
+from OCC.MeshVS import (MeshVS_Mesh, MeshVS_BP_Mesh, MeshVS_MeshPrsBuilder,
 	                    MeshVS_DMF_NodalColorDataPrs)
-from OCC.Core.SMDSAbs import SMDSAbs_Face
+from OCC.SMDSAbs import SMDSAbs_Face
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_modeling_bool_demo.py
+++ b/examples/core_modeling_bool_demo.py
@@ -22,14 +22,14 @@
 
 from math import atan, cos, sin, pi
 
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_Transform, BRepBuilderAPI_MakeWire,
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_Transform, BRepBuilderAPI_MakeWire,
                                 BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeFace)
-from OCC.Core.BRepFeat import BRepFeat_MakeCylindricalHole
-from OCC.Core.BRepPrimAPI import (BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeCylinder,
+from OCC.BRepFeat import BRepFeat_MakeCylindricalHole
+from OCC.BRepPrimAPI import (BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeCylinder,
                              BRepPrimAPI_MakeTorus, BRepPrimAPI_MakeRevol)
-from OCC.Core.TColgp import TColgp_Array1OfPnt
-from OCC.Core.gp import gp_Ax2, gp_Pnt, gp_Dir, gp_Ax1, gp_Trsf, gp_Vec
+from OCC.TColgp import TColgp_Array1OfPnt
+from OCC.gp import gp_Ax2, gp_Pnt, gp_Dir, gp_Ax1, gp_Trsf, gp_Vec
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_modeling_sprocket.py
+++ b/examples/core_modeling_sprocket.py
@@ -23,23 +23,23 @@
 import sys
 from math import pi as M_PI, sin, cos, pow, atan
 
-from OCC.Core.gp import gp_Pnt2d, gp_Ax2d, gp_Dir2d, gp_Circ2d, gp_Origin2d, gp_DX2d, \
+from OCC.gp import gp_Pnt2d, gp_Ax2d, gp_Dir2d, gp_Circ2d, gp_Origin2d, gp_DX2d, \
     gp_Ax2, gp_OX2d, gp_Lin2d, gp_Trsf, gp_XOY, \
     gp_Pnt, gp_Vec, gp_Ax3, gp_Pln, gp_Origin, gp_DX, gp_DY, gp_DZ, gp_OZ
-from OCC.Core.GCE2d import GCE2d_MakeArcOfCircle, GCE2d_MakeCircle, GCE2d_MakeLine
-from OCC.Core.Geom2dAPI import Geom2dAPI_InterCurveCurve
-from OCC.Core.Geom2d import Handle_Geom2d_TrimmedCurve
-from OCC.Core.GeomAPI import geomapi_To3d
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
+from OCC.GCE2d import GCE2d_MakeArcOfCircle, GCE2d_MakeCircle, GCE2d_MakeLine
+from OCC.Geom2dAPI import Geom2dAPI_InterCurveCurve
+from OCC.Geom2d import Handle_Geom2d_TrimmedCurve
+from OCC.GeomAPI import geomapi_To3d
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
                                 BRepBuilderAPI_MakeWire,
                                 BRepBuilderAPI_MakeFace,
                                 BRepBuilderAPI_Transform)
-from OCC.Core.BRepPrimAPI import (BRepPrimAPI_MakePrism, BRepPrimAPI_MakeRevol,
+from OCC.BRepPrimAPI import (BRepPrimAPI_MakePrism, BRepPrimAPI_MakeRevol,
                              BRepPrimAPI_MakeCylinder, BRepPrimAPI_MakeCone)
-from OCC.Core.GccAna import GccAna_Circ2d2TanRad
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
-from OCC.Core.BRepFilletAPI import BRepFilletAPI_MakeFillet2d
-from OCC.Core.BRepTools import BRepTools_WireExplorer
+from OCC.GccAna import GccAna_Circ2d2TanRad
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
+from OCC.BRepFilletAPI import BRepFilletAPI_MakeFillet2d
+from OCC.BRepTools import BRepTools_WireExplorer
 from OCC.Display.SimpleGui import init_display
 
 roller_diameter = 10.2

--- a/examples/core_offscreen_rendering.py
+++ b/examples/core_offscreen_rendering.py
@@ -16,7 +16,7 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.OCCViewer import Display3d, Viewer3d
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
 # create the renderer
 offscreen_renderer = Viewer3d(None)

--- a/examples/core_parallel_slicer.py
+++ b/examples/core_parallel_slicer.py
@@ -24,12 +24,12 @@ if sys.version_info[:3] >= (2, 6, 0):
 else:
     import processing
 
-from OCC.Core.BRep import BRep_Builder
-from OCC.Core.BRepTools import breptools_Read
-from OCC.Core.TopoDS import TopoDS_Shape
-from OCC.Core.gp import gp_Pln, gp_Dir, gp_Pnt
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Section
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+from OCC.BRep import BRep_Builder
+from OCC.BRepTools import breptools_Read
+from OCC.TopoDS import TopoDS_Shape
+from OCC.gp import gp_Pln, gp_Dir, gp_Pnt
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Section
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeFace
 
 from OCC.Display.SimpleGui import init_display
 

--- a/examples/core_shape_pickling.py
+++ b/examples/core_shape_pickling.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 
 import pickle
 

--- a/examples/core_shape_properties.py
+++ b/examples/core_shape_properties.py
@@ -17,9 +17,9 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.GProp import GProp_GProps
-from OCC.Core.BRepGProp import brepgprop_VolumeProperties, brepgprop_SurfaceProperties
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.GProp import GProp_GProps
+from OCC.BRepGProp import brepgprop_VolumeProperties, brepgprop_SurfaceProperties
 
 from OCC.Extend.TopologyUtils import TopologyExplorer
 

--- a/examples/core_simple_mesh.py
+++ b/examples/core_simple_mesh.py
@@ -15,16 +15,16 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.BRep import BRep_Builder, BRep_Tool
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
-from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopoDS import TopoDS_Compound, topods_Face, topods_Edge
-from OCC.Core.TopAbs import TopAbs_FACE
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.gp import gp_Pnt
+from OCC.BRep import BRep_Builder, BRep_Tool
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeSphere
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Fuse
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
+from OCC.BRepMesh import BRepMesh_IncrementalMesh
+from OCC.TopExp import TopExp_Explorer
+from OCC.TopoDS import TopoDS_Compound, topods_Face, topods_Edge
+from OCC.TopAbs import TopAbs_FACE
+from OCC.TopLoc import TopLoc_Location
+from OCC.gp import gp_Pnt
 from OCC.Display.SimpleGui import init_display
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_tesselation_vertices_list.py
+++ b/examples/core_tesselation_vertices_list.py
@@ -15,8 +15,8 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.Visualization import Tesselator
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
+from OCC.Visualization import Tesselator
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeTorus
 
 try:
     import numpy as np

--- a/examples/core_topology_boolean.py
+++ b/examples/core_topology_boolean.py
@@ -17,11 +17,11 @@
 import sys
 import time
 
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse, BRepAlgoAPI_Common, BRepAlgoAPI_Section, BRepAlgoAPI_Cut
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeFace, BRepBuilderAPI_Transform
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeWedge, BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeTorus
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Fuse, BRepAlgoAPI_Common, BRepAlgoAPI_Section, BRepAlgoAPI_Cut
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeFace, BRepBuilderAPI_Transform
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeWedge, BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeTorus
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.gp import gp_Vec, gp_Ax2, gp_Pnt, gp_Dir, gp_Pln, gp_Trsf
+from OCC.gp import gp_Vec, gp_Ax2, gp_Pnt, gp_Dir, gp_Pln, gp_Trsf
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_topology_boolean_general_fuse_algorithm.py
+++ b/examples/core_topology_boolean_general_fuse_algorithm.py
@@ -16,8 +16,8 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.BOPAlgo import BOPAlgo_Builder
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BOPAlgo import BOPAlgo_Builder
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 my_box1 = BRepPrimAPI_MakeBox(10., 20., 30.).Shape()

--- a/examples/core_topology_draft_angle.py
+++ b/examples/core_topology_draft_angle.py
@@ -16,15 +16,15 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-from OCC.Core.gp import gp_Dir, gp_Pln, gp_Ax3, gp_XOY
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_DraftAngle
-from OCC.Core.Precision import precision_Angular
-from OCC.Core.BRep import BRep_Tool_Surface
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopAbs import TopAbs_FACE
-from OCC.Core.Geom import Handle_Geom_Plane_DownCast
-from OCC.Core.TopoDS import topods_Face
+from OCC.gp import gp_Dir, gp_Pln, gp_Ax3, gp_XOY
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepOffsetAPI import BRepOffsetAPI_DraftAngle
+from OCC.Precision import precision_Angular
+from OCC.BRep import BRep_Tool_Surface
+from OCC.TopExp import TopExp_Explorer
+from OCC.TopAbs import TopAbs_FACE
+from OCC.Geom import Handle_Geom_Plane_DownCast
+from OCC.TopoDS import topods_Face
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_edge.py
+++ b/examples/core_topology_edge.py
@@ -17,11 +17,11 @@
 
 import math
 
-from OCC.Core.gp import gp_Pnt, gp_Lin, gp_Ax1, gp_Dir, gp_Elips, gp_Ax2
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
+from OCC.gp import gp_Pnt, gp_Lin, gp_Ax1, gp_Dir, gp_Elips, gp_Ax2
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
                                 BRepBuilderAPI_MakeVertex)
-from OCC.Core.TColgp import TColgp_Array1OfPnt
-from OCC.Core.Geom import Geom_BezierCurve
+from OCC.TColgp import TColgp_Array1OfPnt
+from OCC.Geom import Geom_BezierCurve
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_evolved_shape.py
+++ b/examples/core_topology_evolved_shape.py
@@ -15,10 +15,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakePolygon
-from OCC.Core.GeomAbs import GeomAbs_Arc
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeEvolved
+from OCC.gp import gp_Pnt
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakePolygon
+from OCC.GeomAbs import GeomAbs_Arc
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakeEvolved
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_face.py
+++ b/examples/core_topology_face.py
@@ -17,17 +17,17 @@
 
 import math
 
-from OCC.Core.gp import (gp_Pnt, gp_Sphere, gp_Ax3, gp_Dir, gp_Circ, gp_Ax2,
+from OCC.gp import (gp_Pnt, gp_Sphere, gp_Ax3, gp_Dir, gp_Circ, gp_Ax2,
                     gp_Pnt2d, gp_Dir2d)
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
                                 BRepBuilderAPI_MakeFace,
                                 BRepBuilderAPI_MakeWire)
-from OCC.Core.TColgp import TColgp_Array2OfPnt
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSplineSurface
-from OCC.Core.GeomAbs import GeomAbs_C2
-from OCC.Core.Geom2d import Geom2d_Line
-from OCC.Core.BRepLib import breplib_BuildCurves3d
-from OCC.Core.Quantity import Quantity_Color, Quantity_NOC_PINK
+from OCC.TColgp import TColgp_Array2OfPnt
+from OCC.GeomAPI import GeomAPI_PointsToBSplineSurface
+from OCC.GeomAbs import GeomAbs_C2
+from OCC.Geom2d import Geom2d_Line
+from OCC.BRepLib import breplib_BuildCurves3d
+from OCC.Quantity import Quantity_Color, Quantity_NOC_PINK
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_fillet.py
+++ b/examples/core_topology_fillet.py
@@ -17,12 +17,12 @@
 import sys
 from math import cos, pi
 
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse
-from OCC.Core.BRepFilletAPI import BRepFilletAPI_MakeFillet
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Fuse
+from OCC.BRepFilletAPI import BRepFilletAPI_MakeFillet
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.TColgp import TColgp_Array1OfPnt2d
-from OCC.Core.gp import gp_Ax2, gp_Pnt, gp_Dir, gp_Pnt2d
+from OCC.TColgp import TColgp_Array1OfPnt2d
+from OCC.gp import gp_Ax2, gp_Pnt, gp_Dir, gp_Pnt2d
 from OCC.Extend.TopologyUtils import TopologyExplorer
 
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_glue.py
+++ b/examples/core_topology_glue.py
@@ -1,12 +1,12 @@
-from OCC.Core.BRepFeat import BRepFeat_Gluer
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.BRepFeat import BRepFeat_Gluer
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.LocOpe import LocOpe_FindEdges
-from OCC.Core.TopAbs import TopAbs_FACE
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopLoc import TopLoc_Location
-from OCC.Core.TopoDS import topods_Face
-from OCC.Core.gp import gp_Pnt, gp_Trsf, gp_Vec
+from OCC.LocOpe import LocOpe_FindEdges
+from OCC.TopAbs import TopAbs_FACE
+from OCC.TopExp import TopExp_Explorer
+from OCC.TopLoc import TopLoc_Location
+from OCC.TopoDS import topods_Face
+from OCC.gp import gp_Pnt, gp_Trsf, gp_Vec
 
 from OCC.Extend.ShapeFactory import center_boundingbox
 

--- a/examples/core_topology_heightmap.py
+++ b/examples/core_topology_heightmap.py
@@ -19,16 +19,16 @@ from __future__ import division, print_function
 
 import math
 
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
+from OCC.gp import gp_Pnt
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
                                 BRepBuilderAPI_MakeFace,
                                 BRepBuilderAPI_MakeWire)
-from OCC.Core.TColgp import TColgp_Array2OfPnt
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSplineSurface
-from OCC.Core.GeomFill import GeomFill_SimpleBound, GeomFill_ConstrainedFilling
-from OCC.Core.GeomAbs import GeomAbs_C2
+from OCC.TColgp import TColgp_Array2OfPnt
+from OCC.GeomAPI import GeomAPI_PointsToBSplineSurface
+from OCC.GeomFill import GeomFill_SimpleBound, GeomFill_ConstrainedFilling
+from OCC.GeomAbs import GeomAbs_C2
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.BRepAdaptor import BRepAdaptor_CompCurve, BRepAdaptor_HCompCurve
+from OCC.BRepAdaptor import BRepAdaptor_CompCurve, BRepAdaptor_HCompCurve
 
 try:
     from PIL import Image

--- a/examples/core_topology_local_ops.py
+++ b/examples/core_topology_local_ops.py
@@ -17,24 +17,24 @@
 import sys
 from math import pi
 
-from OCC.Core.BRep import BRep_Tool_Surface
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Section, BRepAlgoAPI_Fuse
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeEdge,
+from OCC.BRep import BRep_Tool_Surface
+from OCC.BRepAlgoAPI import BRepAlgoAPI_Section, BRepAlgoAPI_Fuse
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeEdge,
 	                            BRepBuilderAPI_MakeFace, BRepBuilderAPI_GTransform)
-from OCC.Core.BRepFeat import (BRepFeat_MakePrism, BRepFeat_MakeDPrism, BRepFeat_SplitShape,
+from OCC.BRepFeat import (BRepFeat_MakePrism, BRepFeat_MakeDPrism, BRepFeat_SplitShape,
                           BRepFeat_MakeLinearForm, BRepFeat_MakeRevol)
-from OCC.Core.BRepLib import breplib_BuildCurves3d
-from OCC.Core.BRepOffset import BRepOffset_Skin
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeThickSolid, BRepOffsetAPI_MakeOffsetShape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakePrism
+from OCC.BRepLib import breplib_BuildCurves3d
+from OCC.BRepOffset import BRepOffset_Skin
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakeThickSolid, BRepOffsetAPI_MakeOffsetShape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakePrism
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.GCE2d import GCE2d_MakeLine
-from OCC.Core.Geom import Handle_Geom_Plane_DownCast, Geom_Plane
-from OCC.Core.Geom2d import Geom2d_Circle
-from OCC.Core.GeomAbs import GeomAbs_Arc
-from OCC.Core.TopTools import TopTools_ListOfShape
-from OCC.Core.TopoDS import TopoDS_Face
-from OCC.Core.gp import (gp_Pnt2d, gp_Circ2d, gp_Ax2d, gp_Dir2d, gp_Pnt, gp_Pln,
+from OCC.GCE2d import GCE2d_MakeLine
+from OCC.Geom import Handle_Geom_Plane_DownCast, Geom_Plane
+from OCC.Geom2d import Geom2d_Circle
+from OCC.GeomAbs import GeomAbs_Arc
+from OCC.TopTools import TopTools_ListOfShape
+from OCC.TopoDS import TopoDS_Face
+from OCC.gp import (gp_Pnt2d, gp_Circ2d, gp_Ax2d, gp_Dir2d, gp_Pnt, gp_Pln,
 	                gp_Vec, gp_OX, gp_Trsf, gp_GTrsf)
 
 from OCC.Extend.TopologyUtils import TopologyExplorer

--- a/examples/core_topology_pipe.py
+++ b/examples/core_topology_pipe.py
@@ -19,11 +19,11 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSpline
-from OCC.Core.TColgp import TColgp_Array1OfPnt
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakePipe
+from OCC.gp import gp_Pnt
+from OCC.GeomAPI import GeomAPI_PointsToBSpline
+from OCC.TColgp import TColgp_Array1OfPnt
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire
+from OCC.BRepOffsetAPI import BRepOffsetAPI_MakePipe
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_prism.py
+++ b/examples/core_topology_prism.py
@@ -19,11 +19,11 @@
 
 from __future__ import print_function
 
-from OCC.Core.gp import gp_Pnt, gp_Vec
-from OCC.Core.GeomAPI import GeomAPI_PointsToBSpline
-from OCC.Core.TColgp import TColgp_Array1OfPnt
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism
+from OCC.gp import gp_Pnt, gp_Vec
+from OCC.GeomAPI import GeomAPI_PointsToBSpline
+from OCC.TColgp import TColgp_Array1OfPnt
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
+from OCC.BRepPrimAPI import BRepPrimAPI_MakePrism
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_revolved_shape.py
+++ b/examples/core_topology_revolved_shape.py
@@ -15,10 +15,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 import math
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeFace
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeRevol
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeFace
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeRevol
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.gp import gp_Pnt, gp_Dir, gp_Ax1
+from OCC.gp import gp_Pnt, gp_Dir, gp_Ax1
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_topology_splitter.py
+++ b/examples/core_topology_splitter.py
@@ -19,13 +19,13 @@ from __future__ import print_function
 import sys
 import time
 
-from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, \
+from OCC.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, \
     BRepBuilderAPI_MakeFace
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.GEOMAlgo import GEOMAlgo_Splitter
-from OCC.Core.TopAbs import TopAbs_EDGE
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.gp import gp_Dir, gp_Pln, gp_Pnt
+from OCC.GEOMAlgo import GEOMAlgo_Splitter
+from OCC.TopAbs import TopAbs_EDGE
+from OCC.TopExp import TopExp_Explorer
+from OCC.gp import gp_Dir, gp_Pln, gp_Pnt
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_topology_tetrahedron.py
+++ b/examples/core_topology_tetrahedron.py
@@ -17,8 +17,8 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
+from OCC.gp import gp_Pnt
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeEdge,
                                 BRepBuilderAPI_MakeWire,
                                 BRepBuilderAPI_MakeFace,
                                 BRepBuilderAPI_Sewing)

--- a/examples/core_topology_through_sections.py
+++ b/examples/core_topology_through_sections.py
@@ -15,10 +15,10 @@
 ##You should have received a copy of the GNU Lesser General Public License
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
-from OCC.Core.gp import gp_Dir, gp_Pnt, gp_Circ, gp_Ax2
-from OCC.Core.BRepBuilderAPI import (BRepBuilderAPI_MakeWire,
+from OCC.gp import gp_Dir, gp_Pnt, gp_Circ, gp_Ax2
+from OCC.BRepBuilderAPI import (BRepBuilderAPI_MakeWire,
                                 BRepBuilderAPI_MakeEdge)
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_ThruSections
+from OCC.BRepOffsetAPI import BRepOffsetAPI_ThruSections
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_topology_vertex_filleting.py
+++ b/examples/core_topology_vertex_filleting.py
@@ -20,17 +20,17 @@
 # A sample that shows how to generate the gear geometry according
 # to knowledge
 
-from OCC.Core.BRepFilletAPI import BRepFilletAPI_MakeFillet
-from OCC.Core.BRep import BRep_Tool
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.TopExp import (TopExp_Explorer,
+from OCC.BRepFilletAPI import BRepFilletAPI_MakeFillet
+from OCC.BRep import BRep_Tool
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.TopExp import (TopExp_Explorer,
                         topexp_MapShapesAndAncestors,
                         topexp_FirstVertex,
                         topexp_LastVertex)
-from OCC.Core.TopAbs import TopAbs_VERTEX, TopAbs_EDGE
-from OCC.Core.TopTools import (TopTools_IndexedDataMapOfShapeListOfShape,
+from OCC.TopAbs import TopAbs_VERTEX, TopAbs_EDGE
+from OCC.TopTools import (TopTools_IndexedDataMapOfShapeListOfShape,
                           TopTools_ListIteratorOfListOfShape)
-from OCC.Core.TopoDS import topods_Vertex, topods_Edge
+from OCC.TopoDS import topods_Vertex, topods_Edge
 
 from OCC.Display.SimpleGui import init_display
 display, start_display, add_menu, add_function_to_menu = init_display()

--- a/examples/core_visualization_3d_to_2d_screen_coordinates.py
+++ b/examples/core_visualization_3d_to_2d_screen_coordinates.py
@@ -20,9 +20,9 @@ coordinates in the console.
 """
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Graphic3d import Graphic3d_Camera
-from OCC.Core.TopoDS import topods_Vertex
-from OCC.Core.BRep import BRep_Tool
+from OCC.Graphic3d import Graphic3d_Camera
+from OCC.TopoDS import topods_Vertex
+from OCC.BRep import BRep_Tool
 from OCC.Extend.DataExchange import read_step_file
 
 def vertex_clicked(shp, *kwargs):

--- a/examples/core_visualization_ais_coloredshape.py
+++ b/examples/core_visualization_ais_coloredshape.py
@@ -17,8 +17,8 @@ from __future__ import print_function
 
 from random import random
 
-from OCC.Core.AIS import AIS_ColoredShape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.AIS import AIS_ColoredShape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
 from OCC.Display.OCCViewer import rgb_color
 from OCC.Display.SimpleGui import init_display
 from OCC.Extend.TopologyUtils import TopologyExplorer

--- a/examples/core_visualization_camera.py
+++ b/examples/core_visualization_camera.py
@@ -19,7 +19,7 @@
 
 
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Graphic3d import Graphic3d_Camera
+from OCC.Graphic3d import Graphic3d_Camera
 
 import sys, os
 

--- a/examples/core_visualization_glsl.py
+++ b/examples/core_visualization_glsl.py
@@ -16,12 +16,12 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from OCC.Core.AIS import AIS_Shape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeSphere
+from OCC.AIS import AIS_Shape
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeSphere
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Graphic3d import (Graphic3d_ShaderProgram, Graphic3d_TOS_VERTEX, Graphic3d_TOS_FRAGMENT,
+from OCC.Graphic3d import (Graphic3d_ShaderProgram, Graphic3d_TOS_VERTEX, Graphic3d_TOS_FRAGMENT,
                            Graphic3d_ShaderObject)
-from OCC.Core.TCollection import TCollection_AsciiString
+from OCC.TCollection import TCollection_AsciiString
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_visualization_graphic3d_custom_opengl.py
+++ b/examples/core_visualization_graphic3d_custom_opengl.py
@@ -3,12 +3,12 @@ from __future__ import print_function
 import random
 import warnings
 
-from OCC.Core.Aspect import Aspect_TOL_SOLID
+from OCC.Aspect import Aspect_TOL_SOLID
 from OCC.Display.SimpleGui import init_display
-from OCC.Core.Graphic3d import Graphic3d_ArrayOfPolylines, Graphic3d_AspectLine3d
-from OCC.Core.Prs3d import Prs3d_Root_CurrentGroup, Prs3d_Presentation
-from OCC.Core.Quantity import Quantity_NOC_BLACK, Quantity_Color
-from OCC.Core.gp import gp_Pnt
+from OCC.Graphic3d import Graphic3d_ArrayOfPolylines, Graphic3d_AspectLine3d
+from OCC.Prs3d import Prs3d_Root_CurrentGroup, Prs3d_Presentation
+from OCC.Quantity import Quantity_NOC_BLACK, Quantity_Color
+from OCC.gp import gp_Pnt
 
 display, start_display, add_menu, add_function_to_menu = init_display()
 

--- a/examples/core_visualization_overpaint_viewer.py
+++ b/examples/core_visualization_overpaint_viewer.py
@@ -42,7 +42,7 @@ from OCC.Display.backend import load_any_qt_backend, get_qt_modules
 
 load_any_qt_backend()
 
-QtCore, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
+Q, QtGui, QtWidgets, QtOpenGL = get_qt_modules()
 from OCC.Display.qtDisplay import qtViewer3d
 
 # --------------------------------------------------------------------------
@@ -78,9 +78,9 @@ class Bubble(object):
 
     def updateBrush(self):
         gradient = QtGui.QRadialGradient(
-                QtCore.QPointF(self.radius, self.radius),
+                Q.QPointF(self.radius, self.radius),
                 self.radius,
-                QtCore.QPointF(self.radius * 0.5, self.radius * 0.5))
+                Q.QPointF(self.radius * 0.5, self.radius * 0.5))
         gradient.setColorAt(0, QtGui.QColor(255, 255, 255, 0))
         gradient.setColorAt(0.25, self.innerColor)
         gradient.setColorAt(1, self.outerColor)
@@ -96,7 +96,7 @@ class Bubble(object):
             font = painter.font()
             font.setPointSize(20)
             painter.setFont(font)
-            painter.setPen(QtCore.Qt.red)
+            painter.setPen(Q.Qt.red)
             painter.drawText(0, 0, "so hovering over!!!")
 
         painter.drawEllipse(0, 0, int(2 * self.radius), int(2 * self.radius))
@@ -131,7 +131,7 @@ class Bubble(object):
             self.vel.setY(-self.vel.y())
 
     def rect(self):
-        return QtCore.QRectF(self.position.x() - self.radius,
+        return Q.QRectF(self.position.x() - self.radius,
                              self.position.y() - self.radius, 2 * self.radius,
                              2 * self.radius)
 
@@ -150,8 +150,8 @@ class GLWidget(qtViewer3d):
         # parameters for bubbles
         # ---------------------------------------------------------------------
 
-        midnight = QtCore.QTime(0, 0, 0)
-        random.seed(midnight.secsTo(QtCore.QTime.currentTime()))
+        midnight = Q.QTime(0, 0, 0)
+        random.seed(midnight.secsTo(Q.QTime.currentTime()))
         self.bubbles = []
 
         # parameter for overpainted text box
@@ -165,7 +165,7 @@ class GLWidget(qtViewer3d):
         # "point" conversion takes place implicitly
         # ---------------------------------------------------------------------
 
-        self.lastPos = QtCore.QPoint()
+        self.lastPos = Q.QPoint()
 
         # ---------------------------------------------------------------------
         # GUI parameters
@@ -175,7 +175,7 @@ class GLWidget(qtViewer3d):
         self.setWindowTitle("Overpainting a Scene")
 
         # parameters for overpainting
-        self.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.setAttribute(Q.Qt.WA_NoSystemBackground)
         self.setAutoFillBackground(False)
 
         # ---------------------------------------------------------------------
@@ -191,10 +191,10 @@ class GLWidget(qtViewer3d):
         # ---------------------------------------------------------------------
 
         # QPoint stored on mouse press
-        self._point_on_mouse_press = QtCore.QPoint()
+        self._point_on_mouse_press = Q.QPoint()
 
         # QPoint stored on mouse move
-        self._point_on_mouse_move = QtCore.QPoint()
+        self._point_on_mouse_move = Q.QPoint()
 
         # stores the delta between self._point_on_mouse_press and self._point_on_mouse_move
         self._delta_event_pos = None
@@ -213,9 +213,9 @@ class GLWidget(qtViewer3d):
     @point_on_mouse_press.setter
     def point_on_mouse_press(self, event):
         if isinstance(event, QtGui.QMouseEvent):
-            self._point_on_mouse_press = QtCore.QPoint(event.pos())
-        elif isinstance(event, QtCore.QPoint):
-            self._point_on_mouse_press = QtCore.QPoint(event)
+            self._point_on_mouse_press = Q.QPoint(event.pos())
+        elif isinstance(event, Q.QPoint):
+            self._point_on_mouse_press = Q.QPoint(event)
 
     @property
     def point_on_mouse_move(self):
@@ -226,9 +226,9 @@ class GLWidget(qtViewer3d):
     @point_on_mouse_move.setter
     def point_on_mouse_move(self, event):
         if isinstance(event, (QtGui.QMouseEvent, QtGui.QWheelEvent)):
-            self._point_on_mouse_move = QtCore.QPoint(event.pos())
-        elif isinstance(event, QtCore.QPoint):
-            self._point_on_mouse_move = QtCore.QPoint(event)
+            self._point_on_mouse_move = Q.QPoint(event.pos())
+        elif isinstance(event, Q.QPoint):
+            self._point_on_mouse_move = Q.QPoint(event)
 
     @property
     def delta_mouse_event_pos(self):
@@ -257,7 +257,7 @@ class GLWidget(qtViewer3d):
         self._is_left_mouse_button_surpressed = value
 
     def _setupAnimation(self):
-        self.animationTimer = QtCore.QTimer()
+        self.animationTimer = Q.QTimer()
         self.animationTimer.setSingleShot(False)
         self.animationTimer.timeout.connect(self.animate)
         self.animationTimer.start(25)
@@ -269,16 +269,16 @@ class GLWidget(qtViewer3d):
         button = event.button()
         modifiers = event.modifiers()
 
-        if button == QtCore.Qt.RightButton:
+        if button == Q.Qt.RightButton:
             self.is_right_mouse_button_surpressed = True
-        elif button == QtCore.Qt.LeftButton:
+        elif button == Q.Qt.LeftButton:
             self.is_left_mouse_button_surpressed = True
 
-        if button == QtCore.Qt.RightButton and modifiers == QtCore.Qt.ShiftModifier:
+        if button == Q.Qt.RightButton and modifiers == Q.Qt.ShiftModifier:
             # ON_ZOOM_AREA
             self._drawbox = True
 
-        elif button == QtCore.Qt.LeftButton and modifiers == QtCore.Qt.ShiftModifier:
+        elif button == Q.Qt.LeftButton and modifiers == Q.Qt.ShiftModifier:
             # ON_SELECT_AREA
             self._drawbox = True
             self._select_area = True
@@ -289,17 +289,17 @@ class GLWidget(qtViewer3d):
         button = event.button()
         modifiers = event.modifiers()
 
-        if button == QtCore.Qt.RightButton:
+        if button == Q.Qt.RightButton:
             self.is_right_mouse_button_surpressed = False
-            if modifiers == QtCore.Qt.ShiftModifier:
+            if modifiers == Q.Qt.ShiftModifier:
                 self.current_action = ON_ZOOM_AREA
 
-        if button == QtCore.Qt.LeftButton:
+        if button == Q.Qt.LeftButton:
             self.is_left_mouse_button_surpressed = False
 
             if self._select_area:
                 self.current_action = ON_SELECT_AREA
-            elif modifiers == QtCore.Qt.ShiftModifier:
+            elif modifiers == Q.Qt.ShiftModifier:
                 self.current_action = ON_SHIFT_SELECT
             else:
                 self.current_action = ON_SELECT
@@ -317,23 +317,23 @@ class GLWidget(qtViewer3d):
         modifiers = event.modifiers()
 
         # rotate
-        if buttons == QtCore.Qt.LeftButton and not modifiers == QtCore.Qt.ShiftModifier:
+        if buttons == Q.Qt.LeftButton and not modifiers == Q.Qt.ShiftModifier:
             self.current_action = ON_DYN_ROT
 
         # dynamic zoom
-        elif buttons == QtCore.Qt.RightButton and not modifiers == QtCore.Qt.ShiftModifier:
+        elif buttons == Q.Qt.RightButton and not modifiers == Q.Qt.ShiftModifier:
             self.current_action = ON_DYN_ZOOM
 
         # dynamic panning
-        elif buttons == QtCore.Qt.MidButton:
+        elif buttons == Q.Qt.MidButton:
             self.current_action = ON_DYN_PAN
 
         # zoom window, overpaints rectangle
-        elif buttons == QtCore.Qt.RightButton and modifiers == QtCore.Qt.ShiftModifier:
+        elif buttons == Q.Qt.RightButton and modifiers == Q.Qt.ShiftModifier:
             self.current_action = ON_ZOOM_AREA
 
         # select area
-        elif buttons == QtCore.Qt.LeftButton and modifiers == QtCore.Qt.ShiftModifier:
+        elif buttons == Q.Qt.LeftButton and modifiers == Q.Qt.ShiftModifier:
             self.current_action = ON_SELECT_AREA
 
         self.update()
@@ -553,19 +553,19 @@ class GLWidget(qtViewer3d):
         self.createBubbles(20 - len(self.bubbles))
 
     def sizeHint(self):
-        return QtCore.QSize(800, 600)
+        return Q.QSize(800, 600)
 
     def createBubbles(self, number):
         """ instantiate a `number` of bubbles to be painted on top of
         the viewport
         """
         for _ in range(number):
-            position = QtCore.QPointF(
+            position = Q.QPointF(
                     self.width() * (0.1 + 0.8 * random.random()),
                     self.height() * (0.1 + 0.8 * random.random()))
             radius = min(self.width(), self.height()) * (
                 0.0125 + 0.0875 * random.random())
-            velocity = QtCore.QPointF(
+            velocity = Q.QPointF(
                     self.width() * 0.0125 * (-0.5 + random.random()),
                     self.height() * 0.0125 * (-0.5 + random.random()))
 
@@ -594,7 +594,7 @@ class GLWidget(qtViewer3d):
             pass
 
         else:
-            rect = QtCore.QRect(self.point_on_mouse_press[0],
+            rect = Q.QRect(self.point_on_mouse_press[0],
                                 self.point_on_mouse_press[1], -dx, -dy)
             painter.drawRect(rect)
 
@@ -604,8 +604,8 @@ class GLWidget(qtViewer3d):
         """
         for bubble in self.bubbles:
             bubble_rect = bubble.rect()
-            if bubble_rect.intersects(QtCore.QRectF(event.rect())):
-                pt = QtCore.QPointF(self._point_on_mouse_move)
+            if bubble_rect.intersects(Q.QRectF(event.rect())):
+                pt = Q.QPointF(self._point_on_mouse_move)
                 over_mouse = bubble_rect.contains(pt)
                 bubble.drawBubble(painter, over_mouse)
 
@@ -619,25 +619,25 @@ class GLWidget(qtViewer3d):
 
         rect = metrics.boundingRect(0, 0, self.width() - 2 * border,
                                     int(self.height() * 0.125),
-                                    QtCore.Qt.AlignCenter | QtCore.Qt.TextWordWrap,
+                                    Q.Qt.AlignCenter | Q.Qt.TextWordWrap,
                                     self.text)
 
         painter.setRenderHint(QtGui.QPainter.TextAntialiasing)
 
         painter.fillRect(
-                QtCore.QRect(0, 0, self.width(), rect.height() + 2 * border),
+                Q.QRect(0, 0, self.width(), rect.height() + 2 * border),
                 QtGui.QColor(0, 0, 0, transparency))
 
-        painter.setPen(QtCore.Qt.white)
+        painter.setPen(Q.Qt.white)
 
         painter.fillRect(
-                QtCore.QRect(0, 0, self.width(), rect.height() + 2 * border),
+                Q.QRect(0, 0, self.width(), rect.height() + 2 * border),
                 QtGui.QColor(0, 0, 0, transparency))
 
         painter.drawText((self.width() - rect.width()) / 2, border,
                          rect.width(),
                          rect.height(),
-                         QtCore.Qt.AlignCenter | QtCore.Qt.TextWordWrap,
+                         Q.Qt.AlignCenter | Q.Qt.TextWordWrap,
                          self.text)
 
 

--- a/examples/core_webgl_mesh_quality.py
+++ b/examples/core_webgl_mesh_quality.py
@@ -22,8 +22,8 @@ from __future__ import print_function
 import random
 
 from OCC.Display.WebGl import threejs_renderer
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeTorus
-from OCC.Core.gp import gp_Vec
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeTorus
+from OCC.gp import gp_Vec
 
 from OCC.Extend.ShapeFactory import translate_shp
 

--- a/examples/core_webgl_threejs_random_toruses.py
+++ b/examples/core_webgl_threejs_random_toruses.py
@@ -22,8 +22,8 @@ from __future__ import print_function
 import random
 
 from OCC.Display.WebGl import threejs_renderer
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeTorus
-from OCC.Core.gp import gp_Vec
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeTorus
+from OCC.gp import gp_Vec
 
 from OCC.Extend.ShapeFactory import translate_shp, rotate_shp_3_axis
 

--- a/examples/core_webgl_threejs_torus.py
+++ b/examples/core_webgl_threejs_torus.py
@@ -18,7 +18,7 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.WebGl import threejs_renderer
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeTorus
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeTorus
 
 torus_shp = BRepPrimAPI_MakeTorus(20., 10.).Shape()
 my_renderer = threejs_renderer.ThreejsRenderer()

--- a/examples/core_webgl_x3dom_cylinderhead.py
+++ b/examples/core_webgl_x3dom_cylinderhead.py
@@ -18,9 +18,9 @@
 ##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
 
 from OCC.Display.WebGl import x3dom_renderer
-from OCC.Core.BRep import BRep_Builder
-from OCC.Core.TopoDS import TopoDS_Shape
-from OCC.Core.BRepTools import breptools_Read
+from OCC.BRep import BRep_Builder
+from OCC.TopoDS import TopoDS_Shape
+from OCC.BRepTools import breptools_Read
 
 # loads brep shape
 cylinder_head = TopoDS_Shape()

--- a/examples/core_webgl_x3dom_random_boxes.py
+++ b/examples/core_webgl_x3dom_random_boxes.py
@@ -20,8 +20,8 @@
 import random
 
 from OCC.Display.WebGl import x3dom_renderer
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox
-from OCC.Core.gp import gp_Vec
+from OCC.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCC.gp import gp_Vec
 
 from OCC.Extend.ShapeFactory import translate_shp, rotate_shp_3_axis
 


### PR DESCRIPTION
For 0.18.1, it seems that the `Core` module doesn't exist in the module namespace and all previous submodules (`BRepAPI`, `ChFi2d`, ...) are directly accessed from the `OCC` module itself. Replaced all instances of `OCC.Core.<submodule>` to `OCC.<submodule>`.